### PR TITLE
記事アイキャッチにアイコンを指定できるようにする

### DIFF
--- a/src/components/organisms/PostCard.tsx
+++ b/src/components/organisms/PostCard.tsx
@@ -16,6 +16,7 @@ interface Props {
     coverImage: {
       url: string;
     };
+    coverIcon?: string;
     date: string;
     author: {
       name: string;
@@ -35,13 +36,17 @@ export const PostCard: React.FC<Props> = ({ data, to }) => {
       <Link as={`/${to}/${data.slug}`} href={`/${to}/[slug]`}>
         <a>
           <div className="dataCardContainer">
-            <amp-img
-              width="300"
-              height="200"
-              src={data.coverImage.url}
-              layout="responsive"
-              alt={`${data.title}-cover-image`}
-            />
+            {data.coverIcon ? (
+              <div className="iconEyeCatch">{data.coverIcon}</div>
+            ) : (
+              <amp-img
+                width="300"
+                height="200"
+                src={data.coverImage.url}
+                layout="responsive"
+                alt={`${data.title}-cover-image`}
+              />
+            )}
             <div className="dataCardTextContainer">
               <h3 className="title">{data.title}</h3>
               <p className="excerpt">{data.excerpt}</p>
@@ -57,7 +62,6 @@ export const PostCard: React.FC<Props> = ({ data, to }) => {
             color: #000;
           }
           .dataCardContainer {
-            width: 100%;
             padding-bottom: 15px;
             box-shadow: 0 3px 6px -2px rgb(0 10 60 / 20%);
             border-radius: 2px;
@@ -75,6 +79,15 @@ export const PostCard: React.FC<Props> = ({ data, to }) => {
             margin: 0 20px;
             text-align: center;
           }
+          .iconEyeCatch {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 200px;
+            width: 100%;
+            font-size: 4.8em;
+            background-color: rgba(108, 39, 53, 0.1);
+          }
           .title {
             margin-top: 25px;
             margin-bottom: 0;
@@ -90,6 +103,12 @@ export const PostCard: React.FC<Props> = ({ data, to }) => {
           .date {
             display: block;
             text-align: right;
+          }
+          @media screen and (max-width: 480px) {
+            .dataCardContainer {
+              width: 90%;
+              margin: 0 auto;
+            }
           }
         `}
       </style>

--- a/src/components/organisms/PostHeader.tsx
+++ b/src/components/organisms/PostHeader.tsx
@@ -76,7 +76,7 @@ export const PostHeader: React.FC<Props> = ({
             justify-content: center;
             align-items: center;
             width: 100%;
-            font-size: 4em;
+            font-size: 8em;
           }
           .headerLeft {
             width: 70%;
@@ -96,6 +96,10 @@ export const PostHeader: React.FC<Props> = ({
             }
           }
           @media screen and (max-width: 480px) {
+            .iconEyeCatch {
+              height: auto;
+              font-size: 5em;
+            }
             .headerLeft {
               width: 100%;
             }

--- a/src/components/organisms/PostHeader.tsx
+++ b/src/components/organisms/PostHeader.tsx
@@ -6,6 +6,7 @@ interface Props {
   title: string;
   date: string;
   coverImageUrl: string;
+  coverIcon?: string;
   authorName: string;
   authorPictureUrl: string;
 }
@@ -14,6 +15,7 @@ export const PostHeader: React.FC<Props> = ({
   title,
   date,
   coverImageUrl,
+  coverIcon,
   authorName,
   authorPictureUrl,
 }) => {
@@ -34,14 +36,18 @@ export const PostHeader: React.FC<Props> = ({
               {published.toLocaleDateString()}
             </amp-timeago>
           </div>
-          <amp-img
-            width="300"
-            height="200"
-            src={coverImageUrl}
-            layout="responsive"
-            alt={`${title}-cover-image`}
-            className="ampImg"
-          />
+          {coverIcon ? (
+            <div className="iconEyeCatch">{coverIcon}</div>
+          ) : (
+            <amp-img
+              width="300"
+              height="200"
+              src={coverImageUrl}
+              layout="responsive"
+              alt={`${title}-cover-image`}
+              className="ampImg"
+            />
+          )}
         </div>
         <div className="headerRight">
           <AuthorIntroduce
@@ -64,6 +70,13 @@ export const PostHeader: React.FC<Props> = ({
           .title {
             font-size: 35px;
             margin: 0;
+          }
+          .iconEyeCatch {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            width: 100%;
+            font-size: 4em;
           }
           .headerLeft {
             width: 70%;

--- a/src/lib/apiInterface.ts
+++ b/src/lib/apiInterface.ts
@@ -9,6 +9,7 @@ export interface getPostResponseInterface {
     coverImage: {
       url: string;
     };
+    coverIcon?: string;
     date: string;
     author: {
       name: string;

--- a/src/lib/apiInterface.ts
+++ b/src/lib/apiInterface.ts
@@ -31,6 +31,7 @@ export interface getWorksResponseInterface {
     coverImage: {
       url: string;
     };
+    coverIcon?: string;
     date: string;
     author: {
       name: string;

--- a/src/lib/graphqlSchema.ts
+++ b/src/lib/graphqlSchema.ts
@@ -28,6 +28,7 @@ excerpt
 coverImage {
     url
 }
+coverIcon
 date
 author {
     name

--- a/src/lib/graphqlSchema.ts
+++ b/src/lib/graphqlSchema.ts
@@ -6,6 +6,7 @@ excerpt
 coverImage {
     url
 }
+coverIcon
 date
 author {
     name

--- a/src/pages/posts/[slug].tsx
+++ b/src/pages/posts/[slug].tsx
@@ -39,6 +39,7 @@ const Post: React.FC<PostGetStaticProps> = ({ post, morePosts, preview }) => {
             title={post.title}
             date={post.date}
             coverImageUrl={post.coverImage.url}
+            coverIcon={!!post.coverIcon && post.coverIcon}
             authorName={post.author.name}
             authorPictureUrl={post.author.picture.url}
           />

--- a/src/pages/works/[slug].tsx
+++ b/src/pages/works/[slug].tsx
@@ -39,6 +39,7 @@ const Work: React.FC<WorkGetStaticProps> = ({ work, moreWorks, preview }) => {
             title={work.title}
             date={work.date}
             coverImageUrl={work.coverImage.url}
+            coverIcon={!!work.coverIcon && work.coverIcon}
             authorName={work.author.name}
             authorPictureUrl={work.author.picture.url}
           />


### PR DESCRIPTION
## 実装内容

記事アイキャッチにアイコンを指定できるようにした
- [x] GraphQLスキーマに「Icon」を追加
- [x] contentfulに「Icon」入力欄を作成、入力任意
- [x] ~~画像の入力は任意にする~~
- [x] フロントで受け取って表示させる
  - アイコンがあったらアイコン表示、アイコンがなかったら画像を表示させる
  - 画像はOGPで必要だったため必須のままにした

<img width="1141" alt="スクリーンショット 2021-03-10 1 21 19" src="https://user-images.githubusercontent.com/51112816/110502853-ed0deb80-813e-11eb-8c63-770fbcf67f28.png">

## 備考

- contentfulのリソースに限りがあるので、拘らない場合はアイコンのみを表示させるようにしたい
- イメージとしてはZennのような感じ
- ~~アイコン周辺にグラデーションをかける~~
- グラデーションではなく一色の背景にした